### PR TITLE
Modificar readme y gitmodules

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,6 +1,3 @@
 [Dolphin]
-Timestamp=2016,10,23,1,10,1
+Timestamp=2016,10,27,22,5,15
 Version=3
-
-[Settings]
-HiddenFilesShown=true

--- a/.directory
+++ b/.directory
@@ -1,0 +1,6 @@
+[Dolphin]
+Timestamp=2016,10,23,1,10,1
+Version=3
+
+[Settings]
+HiddenFilesShown=true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "blog"]
 	path = blog
-	url = git@github.com:libreim/blog.git
+	url = https://github.com/libreim/blog.git
 [submodule "awesome"]
 	path = awesome
-	url = git@github.com:libreim/awesome.git
+	url = https://github.com/libreim/awesome.git
 [submodule "calendar"]
 	path = calendar
-	url = git@github.com:libreim/calendar.git
+	url = https://github.com/libreim/calendar.git
 [submodule "assets"]
 	path = assets
-	url = git@github.com:libreim/assets.git
+	url = https://github.com/libreim/assets.git
 [submodule "home"]
 	path = home
-	url = git@github.com:libreim/home.git
+	url = https://github.com/libreim/home.git
 [submodule "foro"]
 	path = foro
-	url = git@github.com:libreim/foro.git
+	url = https://github.com/libreim/foro.git

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # sites
 All sites from @libreim, one deploy
+
+
+## How to build libreim pages locally.
+
+First, fork (optional) and clone this repo, then update all the modules:
+
+    git clone https://github.com/libreim/sites 
+    cd sites
+    git submodule update --init --recursive 
+    
+Once all of the above is done you can do build the proyect: 
+
+    ./build.sh 
+    
+    
+Your local build of the project would be on: http://localhost:8000/ 
+    


### PR DESCRIPTION
Según tengo entendido (quizá me equivoque) el estándar de git para las url a clonar y demás es usar https:/github.com/....., si utilizas git@github.com..... necesitas tener configurada una SSH y no sé qué más historias...

El caso es que yo no la tengo configurada y cuando voy a clonar el repositorio recursivamente me saltan tropecientos errores, a no ser que cambie el git@ por https://

Si lo ejecutas en un pc que no tiene esto configurado (ya sea porque como en mi caso no te has parado a hacerlo o porque no lo estás ejecutando en tu ordenador personal etc...) te puede saltar este error:

Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:libreim/assets.git' into submodule path 'assets' failed

que se soluciona rápidamente cambiando lo que he dicho... Quizá lo hayáis puesto así por algún motivo concreto o no, no lo sé, pero os lo comento porque creo que direccionando con https debería funcionarle a todo el mundo mientras que con git@github habrá personas a las que no les funcione.

pd: la verdad es que no tengo mucha idea de qué utilidad (aparte de esto) tiene el tema de la key SSH de github y demás, tendré que informarme un poquito y ya os cuento, un saludo!

También he modificado el readme para que si alguien con poca idea como yo tiene problemas para montar en local la web sepa que tiene que clonar ESTE repo, recursivamente, y montarlo con el script build.sh 

Un saludo! 
